### PR TITLE
Correct the masking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ storage:
         remote:
           url: https://myserver.net/mydocker.raw
     - path: /etc/systemd/system-generators/torcx-generator
-  links:
-    - path: /etc/extensions/docker-flatcar.raw
-      target: /dev/null
-    - path: /etc/extensions/containerd-flatcar.raw
-      target: /dev/null
+  directories:
+    - path: /etc/extensions/docker-flatcar
+    - path: /etc/extensions/containerd-flatcar
 ```
 
 ## Systemd-sysext on other distributions


### PR DESCRIPTION
The instructions used symlinks to /dev/null to "mask" a sysext image
but it turns out that only empty directories work as of now and the
symlink approach actually doesn't which was an oversight in testing.

